### PR TITLE
Pad privkey bytes with 0s

### DIFF
--- a/js/brainwallet.js
+++ b/js/brainwallet.js
@@ -391,7 +391,11 @@
         if( result.has_private_key ) {
             $("#derived_private_key").val(result.extended_private_key_string("base58"));
 
-            var bytes = [key_coin.private_prefix].concat(result.eckey.priv.toByteArrayUnsigned()).concat([1]);
+            var privkeyBytes = result.eckey.priv.toByteArrayUnsigned();
+            while (privkeyBytes.length < 32) {
+                privkeyBytes.unshift(0);
+            };
+            var bytes = [key_coin.private_prefix].concat(privkeyBytes).concat([1]);
             var checksum = Crypto.SHA256(Crypto.SHA256(bytes, {asBytes: true}), {asBytes: true}).slice(0, 4);
             $("#derived_private_key_wif").val(Bitcoin.Base58.encode(bytes.concat(checksum)))
         } else {


### PR DESCRIPTION
I had a WIF privkey come up with a 5 instead of a L or K. The problem was the BigInteger created a 32 byte privkey with a "0x00" byte as msb. BigInteger's toByteArrayUnsigned() function does not account for that, so we must check the length and pad with 0 bytes to make 32 bytes.