### PR TITLE
add support for blockcypher testnet

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
                 <li><a href="http://dogechain.info/address/" id="doge_main">Dogecoin Mainnet</a></li>
                 <li><a href="#" id="doge_test">Dogecoin Testnet</a></li>
                 <li><a href="https://chainz.cryptoid.info/jbs/" id="jbs_main">Jumbucks Mainnet</a></li>
+                <li><a href="https://dev.blockcypher.com/" id="bcy_test">BlockCypher Testnet</a></li>
                 <!-- Unsupported right now
                 <li><a href="http://explorer.litecoin.net/address/" title="0x30">LTC</a></li>
                 <li><a href="http://explorer.dot-bit.org/a/" title="0x34">NMC</a></li>

--- a/js/bip32.js
+++ b/js/bip32.js
@@ -9,6 +9,8 @@ var DOGECOIN_TESTNET_PUBLIC = 0x0432a9a8;
 var DOGECOIN_TESTNET_PRIVATE = 0x0432a243;
 var JUMBUCKS_MAINNET_PUBLIC = 0x037a689a;
 var JUMBUCKS_MAINNET_PRIVATE = 0x037a6460;
+var BLOCKCYPHER_TESTNET_PUBLIC = 0x2d413ff;
+var BLOCKCYPHER_TESTNET_PRIVATE = 0x2d40fc3;
 var LITECOIN_MAINNET_PUBLIC = 0x019da462;
 var LITECOIN_MAINNET_PRIVATE = 0x019d9cfe;
 var LITECOIN_TESTNET_PUBLIC = 0x0436f6e1;
@@ -51,6 +53,7 @@ BIP32.prototype.init_from_bytes = function(bytes) {
          this.version == DOGECOIN_MAINNET_PRIVATE ||
          this.version == DOGECOIN_TESTNET_PRIVATE ||
          this.version == JUMBUCKS_MAINNET_PRIVATE ||
+         this.version == BLOCKCYPHER_TESTNET_PRIVATE ||
          this.version == LITECOIN_MAINNET_PRIVATE ||
          this.version == LITECOIN_TESTNET_PRIVATE );
 
@@ -60,6 +63,7 @@ BIP32.prototype.init_from_bytes = function(bytes) {
          this.version == DOGECOIN_MAINNET_PUBLIC ||
          this.version == DOGECOIN_TESTNET_PUBLIC ||
          this.version == JUMBUCKS_MAINNET_PUBLIC ||
+         this.version == BLOCKCYPHER_TESTNET_PUBLIC ||
          this.version == LITECOIN_MAINNET_PUBLIC ||
          this.version == LITECOIN_TESTNET_PUBLIC );
 
@@ -110,6 +114,10 @@ BIP32.prototype.build_extended_public_key = function() {
     case JUMBUCKS_MAINNET_PUBLIC:
     case JUMBUCKS_MAINNET_PRIVATE:
         v = JUMBUCKS_MAINNET_PUBLIC;
+        break;
+    case BLOCKCYPHER_TESTNET_PUBLIC:
+    case BLOCKCYPHER_TESTNET_PRIVATE:
+        v = BLOCKCYPHER_TESTNET_PUBLIC;
         break;
     case LITECOIN_MAINNET_PUBLIC:
     case LITECOIN_MAINNET_PRIVATE:
@@ -254,6 +262,7 @@ BIP32.prototype.derive_child = function(i) {
          this.version == DOGECOIN_MAINNET_PRIVATE ||
          this.version == DOGECOIN_TESTNET_PRIVATE ||
          this.version == JUMBUCKS_MAINNET_PRIVATE ||
+         this.version == BLOCKCYPHER_TESTNET_PRIVATE ||
          this.version == LITECOIN_MAINNET_PRIVATE ||
          this.version == LITECOIN_TESTNET_PRIVATE);
 

--- a/js/brainwallet.js
+++ b/js/brainwallet.js
@@ -53,6 +53,14 @@
             bip32_public: JUMBUCKS_MAINNET_PUBLIC,
             bip32_private: JUMBUCKS_MAINNET_PRIVATE
         },
+        bcy_test: {
+            name: "BlockCypher",
+            network: "Testnet",
+            prefix: 0x1b,
+            private_prefix: 0x49,
+            bip32_public: BLOCKCYPHER_TESTNET_PUBLIC,
+            bip32_private: BLOCKCYPHER_TESTNET_PRIVATE
+        },
         ltc_main: {
             name: "Litecoin",
             network: "Mainnet",


### PR DESCRIPTION
blockcypher testnet is a worthless (testing only) coin maintained by blockcypher. More here:
http://dev.blockcypher.com/
